### PR TITLE
Fix cardstackview github issue 387

### DIFF
--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackState.kt
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackState.kt
@@ -57,9 +57,19 @@ class CardStackState {
             val absDx = abs(dx)
             val absDy = abs(dy)
             val ratio = if (absDx < absDy) {
-                absDy / (height / 2.0f)
+                val halfHeight = height / 2.0f
+                if (halfHeight == 0f) {
+                    0f
+                } else {
+                    absDy / halfHeight
+                }
             } else {
-                absDx / (width / 2.0f)
+                val halfWidth = width / 2.0f
+                if (halfWidth == 0f) {
+                    0f
+                } else {
+                    absDx / halfWidth
+                }
             }
             return min(ratio, 1.0f)
         }

--- a/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/internal/CardStackStateTest.kt
+++ b/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/internal/CardStackStateTest.kt
@@ -78,6 +78,31 @@ class CardStackStateTest {
     }
 
     @Test
+    fun `ratio should stay zero when width and height are zero`() {
+        cardStackState.width = 0
+        cardStackState.height = 0
+        cardStackState.dx = 0
+        cardStackState.dy = 0
+        assertEquals(0.0f, cardStackState.ratio, 0.0f)
+    }
+
+    @Test
+    fun `ratio should stay zero when height is zero but dy is non zero`() {
+        cardStackState.height = 0
+        cardStackState.dx = 0
+        cardStackState.dy = 100
+        assertEquals(0.0f, cardStackState.ratio, 0.0f)
+    }
+
+    @Test
+    fun `ratio should stay zero when width is zero but dx is non zero`() {
+        cardStackState.width = 0
+        cardStackState.dx = 100
+        cardStackState.dy = 0
+        assertEquals(0.0f, cardStackState.ratio, 0.0f)
+    }
+
+    @Test
     fun `isSwipeCompleted should return true when conditions are met`() {
         cardStackState.status = CardStackState.Status.ManualSwipeAnimating
         cardStackState.topPosition = 0


### PR DESCRIPTION
Fixes a crash due to `NaN` in `updateScale` by preventing division by zero in the `ratio` getter and adds unit tests for these edge cases.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fddc0ab-c20c-4123-a81a-2a06e3e85b0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0fddc0ab-c20c-4123-a81a-2a06e3e85b0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

