### PR TITLE
Fix cardstackview github issue 370

### DIFF
--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackState.kt
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackState.kt
@@ -56,12 +56,14 @@ class CardStackState {
         get() {
             val absDx = abs(dx)
             val absDy = abs(dy)
-            val ratio = if (absDx < absDy) {
-                absDy / (height / 2.0f)
+            val halfHeight = height / 2.0f
+            val halfWidth = width / 2.0f
+            val rawRatio = if (absDx < absDy) {
+                if (halfHeight == 0f) 0f else absDy / halfHeight
             } else {
-                absDx / (width / 2.0f)
+                if (halfWidth == 0f) 0f else absDx / halfWidth
             }
-            return min(ratio, 1.0f)
+            return min(rawRatio, 1.0f)
         }
 
     val isSwipeCompleted: Boolean

--- a/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/internal/CardStackStateTest.kt
+++ b/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/internal/CardStackStateTest.kt
@@ -78,6 +78,22 @@ class CardStackStateTest {
     }
 
     @Test
+    fun `ratio should be zero when width is zero`() {
+        cardStackState.width = 0
+        cardStackState.dx = 10
+        cardStackState.dy = 0
+        assertEquals(0.0f, cardStackState.ratio, 0.0f)
+    }
+
+    @Test
+    fun `ratio should be zero when height is zero`() {
+        cardStackState.height = 0
+        cardStackState.dx = 0
+        cardStackState.dy = 10
+        assertEquals(0.0f, cardStackState.ratio, 0.0f)
+    }
+
+    @Test
     fun `isSwipeCompleted should return true when conditions are met`() {
         cardStackState.status = CardStackState.Status.ManualSwipeAnimating
         cardStackState.topPosition = 0


### PR DESCRIPTION
Prevent `Float.NaN` in `CardStackState.ratio` by handling zero width/height, fixing a crash reported in #370.

The original `ratio` calculation could result in `Float.NaN` if `height` or `width` were `0`, leading to application crashes. This PR adds checks to return `0f` when the divisor is zero, ensuring `ratio` always returns a valid float. Regression tests are included to cover these edge cases.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc8d62e9-2111-4e91-9a8d-f49b9f4ced77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc8d62e9-2111-4e91-9a8d-f49b9f4ced77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

