### PR TITLE
Fix cardstackview issue 372

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,45 @@ CardStackLayoutManager.setSwipeableMethod(SwipeableMethod.AutomaticAndManual)
 | CardStackListener.onCardAppeared(View view, int position)          | This method is called when the card appeared.                       |
 | CardStackListener.onCardDisappeared(View view, int position)       | This method is called when the card disappeared.                    |
 
+# Wichtige Funktionen
+
+## Automatisches Zurücksetzen von Scroll-Positionen
+
+CardStackView setzt automatisch die Scroll-Positionen von verschachtelten scrollbaren Views zurück, wenn eine Karte recycelt wird. Dies verhindert, dass Scroll-Zustände zwischen verschiedenen Karten "durchbluten".
+
+### Problem
+
+Wenn RecyclerView Views recycelt, werden standardmäßig die Scroll-Positionen von verschachtelten ScrollViews, NestedScrollViews oder HorizontalScrollViews nicht zurückgesetzt. Dies kann dazu führen, dass:
+- Eine neue Karte mit einer bereits gescrollten Position erscheint
+- Benutzer verwirrt sind, weil der Inhalt nicht am Anfang beginnt
+- Die Benutzererfahrung inkonsistent wird
+
+### Lösung
+
+CardStackView implementiert einen automatischen Mechanismus, der:
+1. Jede recycelte Karte erkennt
+2. Rekursiv durch die gesamte View-Hierarchie der Karte geht
+3. Alle scrollbaren Views (ScrollView, NestedScrollView, HorizontalScrollView) auf Position (0, 0) zurücksetzt
+
+### Verwendung
+
+Diese Funktionalität ist **automatisch aktiviert** und erfordert keine zusätzliche Konfiguration. Wenn du jedoch einen eigenen RecyclerListener benötigst, kannst du ihn wie folgt setzen:
+
+```kotlin
+cardStackView.setRecyclerListener { holder ->
+    // Deine eigene Recycling-Logik
+    // Die Scroll-Zurücksetzung erfolgt automatisch vorher
+}
+```
+
+**Wichtig**: Der interne Scroll-Reset-Mechanismus wird immer zuerst ausgeführt, bevor dein eigener RecyclerListener aufgerufen wird.
+
 # Changelog
+
+**3.1.1**
+- Automatisches Zurücksetzen von Scroll-Positionen bei View-Recycling (Fix für Issue #372)
+- Verhindert Scroll-State-Bleed zwischen Karten
+- Unterstützt ScrollView, NestedScrollView und HorizontalScrollView
 
 **3.1.0**
 - improved code quality

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.kt
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.kt
@@ -3,7 +3,12 @@ package com.yuyakaido.android.cardstackview
 import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.widget.HorizontalScrollView
+import android.widget.ScrollView
 import androidx.recyclerview.widget.RecyclerView
+import androidx.core.widget.NestedScrollView
 import com.yuyakaido.android.cardstackview.internal.CardStackDataObserver
 import com.yuyakaido.android.cardstackview.internal.CardStackSnapHelper
 
@@ -15,6 +20,11 @@ class CardStackView @JvmOverloads constructor(
     context!!, attrs, defStyle
 ) {
     private val observer = CardStackDataObserver(this)
+    private var externalRecyclerListener: RecyclerListener? = null
+    internal val scrollStateRecyclerListener = RecyclerListener { holder ->
+        resetScrollState(holder.itemView)
+        externalRecyclerListener?.onViewRecycled(holder)
+    }
 
     init {
         initialize()
@@ -48,6 +58,10 @@ class CardStackView @JvmOverloads constructor(
         return super.onInterceptTouchEvent(event)
     }
 
+    override fun setRecyclerListener(listener: RecyclerListener?) {
+        externalRecyclerListener = listener
+    }
+
     fun swipe() {
         if (layoutManager is CardStackLayoutManager) {
             val manager = layoutManager as CardStackLayoutManager?
@@ -65,5 +79,19 @@ class CardStackView @JvmOverloads constructor(
     private fun initialize() {
         CardStackSnapHelper().attachToRecyclerView(this)
         overScrollMode = OVER_SCROLL_NEVER
+        super.setRecyclerListener(scrollStateRecyclerListener)
+    }
+
+    private fun resetScrollState(view: View) {
+        when (view) {
+            is ScrollView -> view.scrollTo(0, 0)
+            is NestedScrollView -> view.scrollTo(0, 0)
+            is HorizontalScrollView -> view.scrollTo(0, 0)
+        }
+        if (view is ViewGroup) {
+            for (index in 0 until view.childCount) {
+                resetScrollState(view.getChildAt(index))
+            }
+        }
     }
 }

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.kt
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.kt
@@ -12,6 +12,18 @@ import androidx.core.widget.NestedScrollView
 import com.yuyakaido.android.cardstackview.internal.CardStackDataObserver
 import com.yuyakaido.android.cardstackview.internal.CardStackSnapHelper
 
+/**
+ * Eine spezialisierte RecyclerView für die Darstellung von Karten in einem Stapel.
+ *
+ * CardStackView bietet erweiterte Funktionen wie:
+ * - Karten-Swipe-Gesten
+ * - Automatisches Zurücksetzen von Scroll-Positionen bei Recycling
+ * - Stack-basierte Animationen
+ *
+ * @property context Der Android-Context
+ * @property attrs Optionale XML-Attribute
+ * @property defStyle Optionaler Standard-Style
+ */
 class CardStackView @JvmOverloads constructor(
     context: Context?,
     attrs: AttributeSet? = null,
@@ -21,6 +33,17 @@ class CardStackView @JvmOverloads constructor(
 ) {
     private val observer = CardStackDataObserver(this)
     private var externalRecyclerListener: RecyclerListener? = null
+    
+    /**
+     * Interner RecyclerListener, der den Scroll-Zustand von recycelten Views zurücksetzt.
+     *
+     * Dieser Listener wird automatisch aufgerufen, wenn eine Karte recycelt wird, und
+     * stellt sicher, dass alle verschachtelten scrollbaren Views (ScrollView,
+     * NestedScrollView, HorizontalScrollView) auf ihre Ausgangsposition zurückgesetzt werden.
+     * Dies verhindert, dass Scroll-Positionen zwischen verschiedenen Karten "durchbluten".
+     *
+     * Nach dem Zurücksetzen wird auch der externe RecyclerListener (falls vorhanden) aufgerufen.
+     */
     internal val scrollStateRecyclerListener = RecyclerListener { holder ->
         resetScrollState(holder.itemView)
         externalRecyclerListener?.onViewRecycled(holder)
@@ -58,6 +81,15 @@ class CardStackView @JvmOverloads constructor(
         return super.onInterceptTouchEvent(event)
     }
 
+    /**
+     * Setzt einen externen RecyclerListener.
+     *
+     * Der externe Listener wird nach dem internen Scroll-Reset-Mechanismus aufgerufen.
+     * Dies ermöglicht es, eigene Recycling-Logik hinzuzufügen, während die automatische
+     * Scroll-Zurücksetzung weiterhin funktioniert.
+     *
+     * @param listener Der externe RecyclerListener oder null
+     */
     override fun setRecyclerListener(listener: RecyclerListener?) {
         externalRecyclerListener = listener
     }
@@ -82,6 +114,24 @@ class CardStackView @JvmOverloads constructor(
         super.setRecyclerListener(scrollStateRecyclerListener)
     }
 
+    /**
+     * Setzt den Scroll-Zustand einer View und aller verschachtelten Views rekursiv zurück.
+     *
+     * Diese Methode durchläuft die View-Hierarchie und setzt die Scroll-Position von allen
+     * scrollbaren Views auf (0, 0) zurück. Unterstützte View-Typen sind:
+     * - [ScrollView]: Vertikale Scroll-Views
+     * - [NestedScrollView]: Verschachtelte vertikale Scroll-Views
+     * - [HorizontalScrollView]: Horizontale Scroll-Views
+     *
+     * Die rekursive Verarbeitung stellt sicher, dass auch tief verschachtelte scrollbare
+     * Views zurückgesetzt werden.
+     *
+     * **Zweck**: Verhindert, dass Scroll-Positionen beim View-Recycling zwischen verschiedenen
+     * Karten übertragen werden (Scroll-State-Bleed). Ohne diese Funktion könnte eine Karte
+     * mit einer bereits gescrollten Position erscheinen, wenn die View recycelt wurde.
+     *
+     * @param view Die View, deren Scroll-Zustand zurückgesetzt werden soll
+     */
     private fun resetScrollState(view: View) {
         when (view) {
             is ScrollView -> view.scrollTo(0, 0)

--- a/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/CardStackViewTest.kt
+++ b/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/CardStackViewTest.kt
@@ -2,6 +2,8 @@ package com.yuyakaido.android.cardstackview
 
 import android.content.Context
 import android.view.MotionEvent
+import android.view.View
+import android.widget.ScrollView
 import androidx.recyclerview.widget.RecyclerView
 import org.junit.Before
 import org.junit.Test
@@ -137,4 +139,34 @@ class CardStackViewTest {
         cardStackView.onInterceptTouchEvent(motionEvent)
         motionEvent.recycle()
     }
+
+    @Test
+    fun `recycling a view should reset nested ScrollView`() {
+        val scrollView = ScrollView(context)
+        scrollView.addView(View(context))
+        scrollView.scrollTo(0, 200)
+
+        val holder = TestViewHolder(scrollView)
+
+        cardStackView.scrollStateRecyclerListener.onViewRecycled(holder)
+
+        assertEquals(0, scrollView.scrollY)
+        assertEquals(0, scrollView.scrollX)
+    }
+
+    @Test
+    fun `external recycler listener should still be invoked`() {
+        var callbackInvoked = false
+        val externalListener = RecyclerView.RecyclerListener {
+            callbackInvoked = true
+        }
+        cardStackView.setRecyclerListener(externalListener)
+
+        val holder = TestViewHolder(View(context))
+        cardStackView.scrollStateRecyclerListener.onViewRecycled(holder)
+
+        assertTrue(callbackInvoked)
+    }
+
+    private class TestViewHolder(view: View) : RecyclerView.ViewHolder(view)
 }


### PR DESCRIPTION
Reset scroll positions of nested scrollable views when a card is recycled to prevent scroll state bleed between cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-6aec136e-b88c-4ea8-a454-8c5e068145c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6aec136e-b88c-4ea8-a454-8c5e068145c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

