### PR TITLE
Implement cardstackview github issue 294

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ manager.setManualRewindDirections(listOf(Direction.Bottom))
 
 When the user swipes in one of the configured `manualRewindDirections`, the previous card is animated back onto the stack (if available) instead of removing the current card again.
 
+> Hinweis: `manualRewindDirections` dürfen keine Richtung enthalten, die bereits in `setDirections(...)` freigegeben wurde. In diesem Fall wirft der LayoutManager eine `IllegalArgumentException`, damit Swipe- und Rewind-Gesten eindeutig bleiben.
+
 ## Overlay View
 
 | Value |                                                  Sample                                                  |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ manager.setManualRewindDirections(listOf(Direction.Bottom))
 
 When the user swipes in one of the configured `manualRewindDirections`, the previous card is animated back onto the stack (if available) instead of removing the current card again.
 
-> Hinweis: `manualRewindDirections` dürfen keine Richtung enthalten, die bereits in `setDirections(...)` freigegeben wurde. In diesem Fall wirft der LayoutManager eine `IllegalArgumentException`, damit Swipe- und Rewind-Gesten eindeutig bleiben.
+> **Note:** `manualRewindDirections` must not contain any direction that is already enabled in `setDirections(...)`. In this case, the LayoutManager throws an `IllegalArgumentException` to ensure swipe and rewind gestures remain distinct.
 
 ## Overlay View
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ CardStackLayoutManager.setRewindAnimationSetting(setting)
 CardStackView.rewind()
 ```
 
+### Manual rewind gestures
+
+If you want to give users a swipe gesture to bring back the last card, specify which directions should trigger a rewind while dragging:
+
+```kotlin
+manager.setDirections(Direction.VERTICAL)
+manager.setManualRewindDirections(listOf(Direction.Bottom))
+```
+
+When the user swipes in one of the configured `manualRewindDirections`, the previous card is animated back onto the stack (if available) instead of removing the current card again.
+
 ## Overlay View
 
 | Value |                                                  Sample                                                  |

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.kt
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.kt
@@ -455,7 +455,13 @@ class CardStackLayoutManager
         startSmoothScroll(scroller)
     }
 
-    private fun smoothScrollToPrevious(position: Int) {
+    private fun smoothScrollToPrevious(
+        position: Int,
+        scrollType: CardStackSmoothScroller.ScrollType = CardStackSmoothScroller.ScrollType.AutomaticRewind
+    ) {
+        if (position < 0) {
+            return
+        }
         val topView = topView
         if (topView != null) {
             cardStackListener.onCardDisappeared(this.topView, cardStackState.topPosition)
@@ -464,8 +470,7 @@ class CardStackLayoutManager
         cardStackState.proportion = 0.0f
         cardStackState.targetPosition = position
         cardStackState.topPosition--
-        val scroller =
-            CardStackSmoothScroller(CardStackSmoothScroller.ScrollType.AutomaticRewind, this)
+        val scroller = CardStackSmoothScroller(scrollType, this)
         scroller.targetPosition = cardStackState.topPosition
         startSmoothScroll(scroller)
     }
@@ -524,6 +529,10 @@ class CardStackLayoutManager
         cardStackSetting.swipeableMethod = swipeableMethod
     }
 
+    fun setManualRewindDirections(directions: List<Direction>) {
+        cardStackSetting.manualRewindDirections = directions
+    }
+
     fun setSwipeAnimationSetting(swipeAnimationSetting: SwipeAnimationSetting) {
         cardStackSetting.swipeAnimationSetting = swipeAnimationSetting
     }
@@ -534,5 +543,19 @@ class CardStackLayoutManager
 
     fun setOverlayInterpolator(overlayInterpolator: Interpolator) {
         cardStackSetting.overlayInterpolator = overlayInterpolator
+    }
+
+    fun rewindFromDrag() {
+        if (!cardStackSetting.swipeableMethod.canSwipeManually()) {
+            return
+        }
+        val previousPosition = cardStackState.topPosition - 1
+        if (previousPosition < 0) {
+            return
+        }
+        smoothScrollToPrevious(
+            previousPosition,
+            CardStackSmoothScroller.ScrollType.ManualRewind
+        )
     }
 }

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.kt
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.kt
@@ -553,6 +553,14 @@ class CardStackLayoutManager @JvmOverloads constructor(
             Direction.Bottom to R.id.bottom_overlay
         )
         
+        // Icon IDs for each overlay direction (optional, may not exist in all layouts)
+        val overlayIconIds = mapOf(
+            Direction.Left to getResourceId(view, "left_overlay_icon"),
+            Direction.Right to getResourceId(view, "right_overlay_icon"),
+            Direction.Top to getResourceId(view, "top_overlay_icon"),
+            Direction.Bottom to getResourceId(view, "bottom_overlay_icon")
+        )
+        
         // Reset all overlays
         listOf(
             R.id.left_overlay,
@@ -565,10 +573,51 @@ class CardStackLayoutManager @JvmOverloads constructor(
         
         val direction = cardStackState.direction
         val alpha = cardStackSetting.overlayInterpolator.getInterpolation(cardStackState.ratio)
+        val isRewindDirection = cardStackSetting.manualRewindDirections.contains(direction)
         
         overlays[direction]?.let { overlayId ->
-            view.findViewById<View>(overlayId)?.alpha = alpha
+            val overlayView = view.findViewById<View>(overlayId)
+            overlayView?.alpha = alpha
+            
+            // Update icon if it's a rewind direction and icon ID exists
+            overlayIconIds[direction]?.takeIf { it != 0 }?.let { iconId ->
+                view.findViewById<android.widget.ImageView>(iconId)?.let { imageView ->
+                    if (isRewindDirection) {
+                        // Set rewind icon if available
+                        val rewindIconId = view.context.resources.getIdentifier(
+                            "rewind_white_120dp",
+                            "drawable",
+                            view.context.packageName
+                        )
+                        if (rewindIconId != 0) {
+                            imageView.setImageResource(rewindIconId)
+                        }
+                    } else {
+                        // Reset to default icon based on direction
+                        val defaultIconName = when (direction) {
+                            Direction.Left, Direction.Bottom -> "skip_white_120dp"
+                            Direction.Right, Direction.Top -> "like_white_120dp"
+                        }
+                        val defaultIconId = view.context.resources.getIdentifier(
+                            defaultIconName,
+                            "drawable",
+                            view.context.packageName
+                        )
+                        if (defaultIconId != 0) {
+                            imageView.setImageResource(defaultIconId)
+                        }
+                    }
+                }
+            }
         }
+    }
+    
+    private fun getResourceId(view: View, resourceName: String): Int {
+        return view.context.resources.getIdentifier(
+            resourceName,
+            "id",
+            view.context.packageName
+        )
     }
 
     private fun resetOverlay(view: View) {

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.kt
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.kt
@@ -514,6 +514,7 @@ class CardStackLayoutManager
     }
 
     fun setDirections(directions: List<Direction>) {
+        ensureDistinctDirections(directions, cardStackSetting.manualRewindDirections)
         cardStackSetting.directions = directions
     }
 
@@ -530,6 +531,7 @@ class CardStackLayoutManager
     }
 
     fun setManualRewindDirections(directions: List<Direction>) {
+        ensureDistinctDirections(cardStackSetting.directions, directions)
         cardStackSetting.manualRewindDirections = directions
     }
 
@@ -543,6 +545,16 @@ class CardStackLayoutManager
 
     fun setOverlayInterpolator(overlayInterpolator: Interpolator) {
         cardStackSetting.overlayInterpolator = overlayInterpolator
+    }
+
+    private fun ensureDistinctDirections(
+        swipeDirections: List<Direction>,
+        rewindDirections: List<Direction>
+    ) {
+        val conflict = swipeDirections.intersect(rewindDirections.toSet())
+        require(conflict.isEmpty()) {
+            "Swipe directions and manual rewind directions must not overlap: $conflict"
+        }
     }
 
     fun rewindFromDrag() {

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSetting.kt
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSetting.kt
@@ -18,6 +18,7 @@ class CardStackSetting {
     var maxDegree: Float = 20.0f
     @JvmField
     var directions: List<Direction> = Direction.HORIZONTAL
+    var manualRewindDirections: List<Direction> = emptyList()
     var canScrollHorizontal: Boolean = true
     var canScrollVertical: Boolean = true
     var swipeableMethod: SwipeableMethod = SwipeableMethod.AutomaticAndManual

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSmoothScroller.kt
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSmoothScroller.kt
@@ -14,7 +14,8 @@ class CardStackSmoothScroller(
         AutomaticSwipe,
         AutomaticRewind,
         ManualSwipe,
-        ManualCancel
+        ManualCancel,
+        ManualRewind
     }
 
     override fun onSeekTargetStep(
@@ -23,7 +24,7 @@ class CardStackSmoothScroller(
         state: RecyclerView.State,
         action: Action
     ) {
-        if (type == ScrollType.AutomaticRewind) {
+        if (type == ScrollType.AutomaticRewind || type == ScrollType.ManualRewind) {
             val setting = manager.cardStackSetting.rewindAnimationSetting
             action.update(
                 -getDx(setting),
@@ -54,6 +55,16 @@ class CardStackSmoothScroller(
             }
 
             ScrollType.AutomaticRewind -> {
+                setting = manager.cardStackSetting.rewindAnimationSetting
+                action.update(
+                    x,
+                    y,
+                    setting.getDuration(),
+                    setting.getInterpolator()
+                )
+            }
+
+            ScrollType.ManualRewind -> {
                 setting = manager.cardStackSetting.rewindAnimationSetting
                 action.update(
                     x,
@@ -97,6 +108,7 @@ class CardStackSmoothScroller(
             }
 
             ScrollType.AutomaticRewind -> state.next(CardStackState.Status.RewindAnimating)
+            ScrollType.ManualRewind -> state.next(CardStackState.Status.RewindAnimating)
             ScrollType.ManualSwipe -> {
                 state.next(CardStackState.Status.ManualSwipeAnimating)
                 listener.onCardDisappeared(manager.topView, manager.topPosition)
@@ -110,7 +122,13 @@ class CardStackSmoothScroller(
         val listener = manager.cardStackListener
         when (type) {
             ScrollType.AutomaticSwipe -> {}
+
             ScrollType.AutomaticRewind -> {
+                listener.onCardRewound()
+                listener.onCardAppeared(manager.topView, manager.topPosition)
+            }
+
+            ScrollType.ManualRewind -> {
                 listener.onCardRewound()
                 listener.onCardAppeared(manager.topView, manager.topPosition)
             }

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSnapHelper.kt
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSnapHelper.kt
@@ -28,7 +28,20 @@ class CardStackSnapHelper : SnapHelper() {
                     val duration = fromVelocity(if (velocityY < velocityX) velocityX else velocityY)
                     if (duration == Duration.Fast || setting.swipeThreshold < horizontal || setting.swipeThreshold < vertical) {
                         val state = layoutManager.cardStackState
-                        if (setting.directions.contains(state.direction)) {
+                        val direction = state.direction
+
+                        val shouldManualRewind =
+                            setting.manualRewindDirections.contains(direction) &&
+                                    state.topPosition > 0
+
+                        if (shouldManualRewind) {
+                            this.velocityX = 0
+                            this.velocityY = 0
+                            layoutManager.rewindFromDrag()
+                            return IntArray(2)
+                        }
+
+                        if (setting.directions.contains(direction)) {
                             state.targetPosition = state.topPosition + 1
 
                             val swipeAnimationSetting = SwipeAnimationSetting.Builder()

--- a/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/CardStackLayoutManagerTest.kt
+++ b/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/CardStackLayoutManagerTest.kt
@@ -210,6 +210,13 @@ class CardStackLayoutManagerTest {
     }
 
     @Test
+    fun `setManualRewindDirections should update setting`() {
+        val rewinds = listOf(Direction.Bottom)
+        layoutManager.setManualRewindDirections(rewinds)
+        assertEquals(rewinds, layoutManager.cardStackSetting.manualRewindDirections)
+    }
+
+    @Test
     fun `setCanScrollHorizontal should update setting`() {
         layoutManager.setCanScrollHorizontal(false)
         assertFalse(layoutManager.cardStackSetting.canScrollHorizontal)

--- a/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/CardStackLayoutManagerTest.kt
+++ b/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/CardStackLayoutManagerTest.kt
@@ -217,6 +217,28 @@ class CardStackLayoutManagerTest {
     }
 
     @Test
+    fun `setDirections should throw when overlapping manual rewind directions`() {
+        layoutManager.setManualRewindDirections(listOf(Direction.Bottom))
+        try {
+            layoutManager.setDirections(listOf(Direction.Bottom, Direction.Top))
+            fail("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message?.contains("must not overlap") == true)
+        }
+    }
+
+    @Test
+    fun `setManualRewindDirections should throw when overlapping swipe directions`() {
+        layoutManager.setDirections(listOf(Direction.Left, Direction.Right))
+        try {
+            layoutManager.setManualRewindDirections(listOf(Direction.Left))
+            fail("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(e.message?.contains("must not overlap") == true)
+        }
+    }
+
+    @Test
     fun `setCanScrollHorizontal should update setting`() {
         layoutManager.setCanScrollHorizontal(false)
         assertFalse(layoutManager.cardStackSetting.canScrollHorizontal)

--- a/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/internal/CardStackSettingTest.kt
+++ b/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/internal/CardStackSettingTest.kt
@@ -26,6 +26,7 @@ class CardStackSettingTest {
         assertEquals(0.3f, cardStackSetting.swipeThreshold, 0.01f)
         assertEquals(20.0f, cardStackSetting.maxDegree, 0.01f)
         assertEquals(Direction.HORIZONTAL, cardStackSetting.directions)
+        assertTrue(cardStackSetting.manualRewindDirections.isEmpty())
         assertTrue(cardStackSetting.canScrollHorizontal)
         assertTrue(cardStackSetting.canScrollVertical)
         assertEquals(SwipeableMethod.AutomaticAndManual, cardStackSetting.swipeableMethod)
@@ -75,6 +76,13 @@ class CardStackSettingTest {
         val customDirections = listOf(Direction.Left, Direction.Right)
         cardStackSetting.directions = customDirections
         assertEquals(customDirections, cardStackSetting.directions)
+    }
+
+    @Test
+    fun `manualRewindDirections should be settable`() {
+        val rewinds = listOf(Direction.Bottom)
+        cardStackSetting.manualRewindDirections = rewinds
+        assertEquals(rewinds, cardStackSetting.manualRewindDirections)
     }
 
     @Test

--- a/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/internal/CardStackSnapHelperTest.kt
+++ b/cardstackview/src/test/java/com/yuyakaido/android/cardstackview/internal/CardStackSnapHelperTest.kt
@@ -1,0 +1,58 @@
+package com.yuyakaido.android.cardstackview.internal
+
+import android.view.View
+import com.yuyakaido.android.cardstackview.CardStackLayoutManager
+import com.yuyakaido.android.cardstackview.Direction
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CardStackSnapHelperTest {
+
+    private lateinit var snapHelper: CardStackSnapHelper
+    private lateinit var layoutManager: CardStackLayoutManager
+    private lateinit var targetView: View
+    private lateinit var setting: CardStackSetting
+    private lateinit var state: CardStackState
+
+    @Before
+    fun setUp() {
+        snapHelper = CardStackSnapHelper()
+        layoutManager = mock(CardStackLayoutManager::class.java)
+        targetView = mock(View::class.java)
+        setting = CardStackSetting()
+        state = CardStackState()
+
+        `when`(layoutManager.cardStackSetting).thenReturn(setting)
+        `when`(layoutManager.cardStackState).thenReturn(state)
+        `when`(layoutManager.topPosition).thenReturn(1)
+        `when`(layoutManager.findViewByPosition(anyInt())).thenReturn(targetView)
+    }
+
+    @Test
+    fun `calculateDistanceToFinalSnap should trigger manual rewind when configured`() {
+        setting.directions = Direction.VERTICAL
+        setting.manualRewindDirections = listOf(Direction.Bottom)
+
+        state.topPosition = 1
+        state.width = 100
+        state.height = 100
+        state.dx = 0
+        state.dy = 100
+
+        `when`(targetView.translationX).thenReturn(0f)
+        `when`(targetView.translationY).thenReturn(100f)
+        `when`(targetView.width).thenReturn(100)
+        `when`(targetView.height).thenReturn(100)
+
+        snapHelper.calculateDistanceToFinalSnap(layoutManager, targetView)
+
+        verify(layoutManager).rewindFromDrag()
+    }
+}

--- a/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/MainActivity.kt
+++ b/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/MainActivity.kt
@@ -186,6 +186,8 @@ class MainActivity : AppCompatActivity(), CardStackListener {
         manager.setSwipeThreshold(0.3f)
         manager.setMaxDegree(20.0f)
         manager.setDirections(Direction.HORIZONTAL)
+        // Enable manual rewind gesture: swipe down to bring back previous card
+        manager.setManualRewindDirections(listOf(Direction.Bottom))
         manager.setCanScrollHorizontal(true)
         manager.setCanScrollVertical(true)
         manager.setSwipeableMethod(SwipeableMethod.AutomaticAndManual)
@@ -201,6 +203,8 @@ class MainActivity : AppCompatActivity(), CardStackListener {
         manager.setSwipeThreshold(0.25f)
         manager.setMaxDegree(0.0f)
         manager.setDirections(Direction.VERTICAL)
+        // Enable manual rewind gesture: swipe left to bring back previous card
+        manager.setManualRewindDirections(listOf(Direction.Left))
         manager.setCanScrollHorizontal(false)
         manager.setCanScrollVertical(true)
         manager.setSwipeableMethod(SwipeableMethod.AutomaticAndManual)

--- a/sample/src/main/res/drawable/rewind_white_120dp.xml
+++ b/sample/src/main/res/drawable/rewind_white_120dp.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="120dp"
+        android:height="120dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#AAFFFFFF"
+        android:pathData="M12,5V1L7,6l5,5V7c3.31,0 6,2.69 6,6s-2.69,6 -6,6 -6,-2.69 -6,-6H4c0,4.42 3.58,8 8,8s8,-3.58 8,-8 -3.58,-8 -8,-8z"/>
+</vector>
+

--- a/sample/src/main/res/layout/item_spot.xml
+++ b/sample/src/main/res/layout/item_spot.xml
@@ -53,6 +53,7 @@
         android:background="@drawable/overlay_black">
 
         <ImageView
+            android:id="@+id/left_overlay_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@drawable/skip_white_120dp"
@@ -67,6 +68,7 @@
         android:background="@drawable/overlay_black">
 
         <ImageView
+            android:id="@+id/right_overlay_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@drawable/like_white_120dp"
@@ -81,6 +83,7 @@
         android:background="@drawable/overlay_black">
 
         <ImageView
+            android:id="@+id/top_overlay_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@drawable/like_white_120dp"
@@ -95,11 +98,13 @@
         android:background="@drawable/overlay_black">
 
         <ImageView
+            android:id="@+id/bottom_overlay_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@drawable/skip_white_120dp"
             android:layout_gravity="center"/>
 
     </FrameLayout>
+
 
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
Add manual rewind gestures to allow users to swipe and bring back the last card, addressing issue #294.

The `CardStackSnapHelper` now checks for configured `manualRewindDirections` during a drag gesture. If a matching direction is detected, it triggers a `rewindFromDrag()` action in the `CardStackLayoutManager` instead of processing a regular swipe, animating the previous card back onto the stack.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b93c5b0-98f7-43c8-a8f0-a99a379c244f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7b93c5b0-98f7-43c8-a8f0-a99a379c244f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

